### PR TITLE
fix: added config loading in test command, before model creation, to …

### DIFF
--- a/src/cli/commands/Test.c
+++ b/src/cli/commands/Test.c
@@ -68,6 +68,14 @@ static int testSingleImage(CommandArgs args) {
     }
     
     int inputSize = args.gridSize * args.gridSize;
+
+    // Load best configuration if available (for correct hidden size)
+    char configFile[256];
+    const char *datasetName = args.dataset == DATASET_SPEC_DIGITS ? "digits" : "alpha";
+    const char *datasetType = args.useStatic ? "static" : "png";
+    snprintf(configFile, sizeof(configFile), "IO/configs/best_config_%s_%s.txt",
+             datasetName, datasetType);
+    loadBestConfig(configFile);
     
     // Create model
     int dims[] = {inputSize, g_trainConfig.hiddenSize, outputSize};
@@ -221,6 +229,14 @@ static int testDataset(CommandArgs args) {
         arenaFree(scratch);
         return 1;
     }
+
+    // Load best configuration if available (for correct hidden size)
+    char configFile[256];
+    const char *datasetName = args.dataset == DATASET_SPEC_DIGITS ? "digits" : "alpha";
+    const char *datasetType = args.useStatic ? "static" : "png";
+    snprintf(configFile, sizeof(configFile), "IO/configs/best_config_%s_%s.txt",
+             datasetName, datasetType);
+    loadBestConfig(configFile);
     
     // Create model
     int dims[] = {ds->inputSize, g_trainConfig.hiddenSize, ds->outputSize};


### PR DESCRIPTION
…prevent layer hidden size mismatch

## Description
Brief description of the changes in this PR.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Documentation update.
- [ ] Performance improvement.
- [ ] Code refactoring.
- [ ] CI/CD improvement.

## Related Issues
Fixes #10 .

## Changes Made
- Added config loading before model creation on function test command, Test.c

## Testing Performed
- [x] Compiled successfully.
- [x] Ran all existing tests.
- [ ] Added new tests for new features.
- [x] Tested on Linux.
- [ ] Tested on macOS.
- [ ] Ran benchmark to check performance impact.

### Test Commands
```bash
# Commands used to test
# pex.
make clean && make
./miniAI test --model IO/models/digit_brain.bin --dataset digits --static
```

### Test Results
```
Paste relevant test output here
```
```bash
./miniAI train --dataset digits --data
./miniAI test --dataset digits --data 
```

## Documentation
- [ ] Updated README.md.
- [X] Updated inline code comments.
- [ ] Added/updated examples.

## Code Quality
- [X] Code follows the project's style guidelines.
- [X] Self-review of code completed.
- [X] No new compiler warnings.
- [X] No memory leaks (tested with valgrind).
- [X] Maintains zero-dependency philosophy.

## Screenshots (if applicable)
Add screenshots or terminal output showing the changes.

## Performance Impact
- [X] No performance impact.
- [ ] Performance improved.
- [ ] Performance degraded (explain why acceptable below).

**Details:**

## Checklist
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [X] Any dependent changes have been merged and published.

Closes #10 